### PR TITLE
Removing settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,6 @@ JSPM automatically installs and configures this module's dependencies for you. H
 * dialogLoader requires [SystemJS](https://github.com/systemjs/systemjs) and will only work with v0.19.x or earlier, as it uses its `System.import()` method to load modules.
 * [Mutation Observer](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
 
-## Options
-#### options.enableObservation
-Type: `boolean`
-Setting this option to `false` prevents dialogLoader from observing the page for added dialog elements. 
-Defaults to `true`.
-
-#### options.observedEl
-Type: `Element`
-The element to be observed for changes. 
-Defaults to `document.body`.
-
 ## CSS Notes
 Include the following CSS in a project to prevent unwated IE issues:
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dialogLoader",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Asynchronously load and register HTML dialog elements for cross-browser support.",
     "keywords": [
         "DEGJS"

--- a/src/dialogLoader.js
+++ b/src/dialogLoader.js
@@ -1,26 +1,19 @@
 import dialogPolyfill from 'dialog-polyfill';
 
-const dialogLoader = function(options = {}) {
+const dialogLoader = function() {
 
-    const defaults = {
-        enableObservation: true,
-        observedEl: document.body
-    };
-    
     const mutationConfig = {
         childList: true,
         attributes: false,
         characterData: false
     };
 
-    const settings = {...defaults, ...options};
+    const observedEl = document.body;
 
     function init() {
         initDialogsOnPage();
-        if(settings.enableObservation === true){
-            const observer = new MutationObserver(onMutation);
-            observer.observe(settings.observedEl, mutationConfig);
-        }
+        const observer = new MutationObserver(onMutation);
+        observer.observe(observedEl, mutationConfig);
     }
 
     function initDialogsOnPage(){


### PR DESCRIPTION
Removing settings because there was no way to set them as a singleton.

They were also unnecessary.